### PR TITLE
Let Ansible playbooks (file 01 and 02) only be executed for `example/standalone_git`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Updated 
 - Updated tests with parameters #39
-- Changed Ansible playbooks `01_put_secrets_vault.yml` and `02_put_variables_consul.yml`, such that they only execute for example/standalone_git. 
+- Changed Ansible playbooks `01_put_secrets_vault.yml` and `02_put_variables_consul.yml`, such that they only execute for example/standalone_git. #43
 
 ## [0.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Updated 
 - Updated tests with parameters #39
+- Changed Ansible playbooks `01_put_secrets_vault.yml` and `02_put_variables_consul.yml`, such that they only execute for example/standalone_git. 
 
 ## [0.2.1]
 

--- a/dev/ansible/01_put_secrets_vault.yml
+++ b/dev/ansible/01_put_secrets_vault.yml
@@ -1,3 +1,6 @@
+- name: Running example/{{ mode }}
+  set_fact:
+    mode: "{{ mode }}"
 
 - name: Put Secrets with Vault
   shell: vault kv put secret/github git_access_user="{{ user }}" git_access_password="{{ token }}"
@@ -5,3 +8,4 @@
   environment:
     VAULT_ADDR: "{{ lookup('env', 'VAULT_ADDR') }}"
     VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
+  when: mode == "standalone_git"

--- a/dev/ansible/02_put_variables_consul.yml
+++ b/dev/ansible/02_put_variables_consul.yml
@@ -1,12 +1,19 @@
+- name: Running example/{{ mode }}
+  set_fact:
+    mode: "{{ mode }}"
+
 - name: Put repo value in Consul Key Value Store
   shell: consul kv put github/repo "{{ repo }}"
   run_once: true
   environment:
     CONSUL_HTTP_ADDR: "{{ lookup('env', 'CONSUL_HTTP_ADDR') }}"
     CONSUL_HTTP_TOKEN: "{{ lookup('env', 'consul_master_token') }}"
+  when: mode == "standalone_git"
+
 - name: Put branch value in Consul Key Value Store
   shell: consul kv put github/branch "{{ branch }}"
   run_once: true
   environment:
     CONSUL_HTTP_ADDR: "{{ lookup('env', 'CONSUL_HTTP_ADDR') }}"
     CONSUL_HTTP_TOKEN: "{{ lookup('env', 'consul_master_token') }}"
+  when: mode == "standalone_git"


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #43 

## What was added/changed/fixed?
Fixed bug in issue #43.
Changed Ansible playbooks `01_put_secrets_vault.yml` and `02_put_variables_consul.yml`, such that they only execute for example/standalone_git.

## Checklist (after created PR)
- [x] Added reviewers
- [ ] Added assignee(s)
- [x] Added label(s)
- [ ] Added to project
- [x] Added to milestone
- Need to update documentation? (Y/n)